### PR TITLE
return true for additionalProperties, when nothing special is defined

### DIFF
--- a/src/Schema.php
+++ b/src/Schema.php
@@ -95,6 +95,18 @@ class Schema extends AbstractModel
             return ['$ref' => $this->getRef()];
         }
 
+        /*
+         * if additionalProperties has no special types/refs, it should return {} or true
+         *  according to https://swagger.io/docs/specification/data-models/dictionaries/
+         * Without the following code, it returns a [], which is wrong/not valid.
+         */
+        if ($this->additionalProperties instanceof self) {
+            $this->additionalProperties = $this->additionalProperties->toArray();
+            if ($this->additionalProperties === []) {
+                $this->additionalProperties = new \stdClass();
+            }
+        }
+
         return array_merge([
             'title' => $this->title,
             'discriminator' => $this->discriminator,


### PR DESCRIPTION
if additionalProperties has no special types/refs, it should return {} or true
according to https://swagger.io/docs/specification/data-models/dictionaries/
Without the following code, it returns a [], which is wrong/not valid.

Not sure, that's the best way/place to do this, or if the "on top" libraries do something wrong. In my case it comes from https://github.com/zircote/swagger-php with the following annotation

```php
     *     @SWG\Schema(
     *       additionalProperties={},
```
(with true, many other things break..)