### PR TITLE
Make `AbstractModel::doMerge()` abstract instead of call a nonexistent method `parse()`

### DIFF
--- a/src/AbstractModel.php
+++ b/src/AbstractModel.php
@@ -23,11 +23,6 @@ abstract class AbstractModel
         return $this->doMerge($this->normalize($data), $overwrite);
     }
 
-    protected function doMerge($data, $overwrite = false)
-    {
-        $this->parse($data);
-    }
-
     public function toArray()
     {
         $return = [];
@@ -52,6 +47,8 @@ abstract class AbstractModel
 
         return $return;
     }
+
+    abstract protected function doMerge($data, $overwrite = false);
 
     protected function normalize($data)
     {


### PR DESCRIPTION
|Q            |A     |
|---          |---   |
|Branch       |master|
|Bug fix?     |yes    |
|New feature? |no    |
|BC breaks?   |no    |
|Deprecations?|no    |
|Tests pass?  |yes   |
|Fixed tickets|n/a   |
|License      |MIT   |
|Doc PR       |n/a   |

The issue was introduced at a37a234e9734cfc1d88d173417b1b1cb1485fa83.